### PR TITLE
Release/0.1.0 - Trinket M0 supported

### DIFF
--- a/READY.FOR.RELEASE
+++ b/READY.FOR.RELEASE
@@ -1,0 +1,42 @@
+Release: 0.1.0 testing-aa-  shred: 4737-a3d-00a-
+
+Wed Oct 30 18:57:28 UTC 2019
+
+On branch testing-aa-
+
+Wed Oct 30 18:57:28 UTC 2019 0.1.0 testing-aa-  shred: 4737-a3d-00a-
+
+commit c5d1558cf4bbf50cb334c0123a25dcdc35abac91
+Author: wa1tnr
+Date:   Wed Oct 30 19:46:31 2019 +0000
+
+    default no NEO_PIXEL support
+
+warm
+ warm boot message - early bird.
+ KAN-MALAMUTE  DEV - gen-exp  30 Oct 2019
+          type 'warm' to reboot
+ Wed Oct 30 18:57:28 UTC 2019   Trinket M0 default +DotStar
+ 4737-a3d-00a-
+
+     ainsuForth - 2019 October - wa1tnr    words: 80
+         YAFFA - Yet Another Forth For Arduino,
+         Copyright (C) 2012 Stuart Wood
+
+This release is the very first (in October, 2019).
+
+Currently expects Trinket M0 as the target board.
+Limited support for other boards - untested and
+is stale code/project (hasn't seen new development
+in more than a year).
+
+Derivative work: ainsuForth-gen-exp-m4 (continuing).
+That repository, though named with 'm4' should generally
+be compatible with M0 targets as well, so long as they
+also have SPI flashROM chips (external to the MCU) on
+the target boards (aka 'Express' boards from Adafruit).
+
+This (very repository) then, is oriented towards the
+M0 non-express boards, such as Feather M0, Trinket M0
+and Gemma M0.  Currently only tested (October 2019)
+against Trinket M0.

--- a/ainsuForth-gen-exp.ino
+++ b/ainsuForth-gen-exp.ino
@@ -1,7 +1,16 @@
+// Wed Oct 30 18:57:28 UTC 2019
+// 4737-a3d-00a- // ainsuForth-gen-exp
+
+// filgar   kandra   helgar   tronde
+
+// On branch testing-aa- / pre-release of 0.1.0
+
+// Purpose of update: make sure Trinket M0 will operate,
+// especially its onboard DotStar RGB LED.  30 October 2019
+
+
 // Wed Jan 31 00:27:18 UTC 2018
 // 4737-a0e-01a-
-
-// kandra helgar tronde
 
 
 // .arduino15/packages/adafruit/hardware/samd/1.0.21/variants/feather_m0_express/variant.h

--- a/ainsuForthsketch.cpp
+++ b/ainsuForthsketch.cpp
@@ -1,18 +1,28 @@
+// Wed Oct 30 18:57:28 UTC 2019
+// 4737-a3d-00a- // ainsuForth-gen-exp
+
+// On branch testing-aa- / pre-release of 0.1.0
+
+// NOTE - the sketch.cpp file (this file) serves the exact
+// same purpose as the (more usual) sketch.ino file does,
+// in a standard Arduino sketch.
+
+// Currently, sketch.cpp is renamed to ainsuForthsketch.cpp for
+// rapid identification, while maintaining some uniqueness. ;)
+
+// In the present scheme, the standard sketch.ino type file
+// remains unpopulated (and currently only contains comments).
+
+// This is correct and normal, for this repository. ;)
+// wa1tnr
+// 30 October 2019
+
 // Wed Jan 31 00:27:18 UTC 2018
 // 4737-a0e-01a-
 
 
-
 // Tue Jan 16 02:30:09 UTC 2018
 // 4737-a0d-05j-
-
-
-// Tue Jan 16 02:20:48 UTC 2018
-// 4737-a0d-05g-
-
-
-// Tue Jan 16 01:14:29 UTC 2018
-// 4737-a0d-05f-
 
 // Mon Jan 15 19:19:47 UTC 2018
 // 4737-a0d-05d-
@@ -44,6 +54,9 @@
 // Sun Aug  6 20:09:53 UTC 2017
 // 4735-b0f-03-
 
+#include <Arduino.h>
+#include "yaffa.h"
+
 // poor practice -- hard coded the answer:
 #ifdef HAS_DOTSTAR_LIB
 // d#ifndef HAS_DOTSTAR_LIB
@@ -57,12 +70,11 @@
 #include "src/kernel/getline.h"
 
 
+
 #ifdef HAS_DOTSTAR_LIB
 #include "src/periph/dotstar.h"
 #endif
 
-#include <Arduino.h>
-#include "yaffa.h"
 #include "ainsuForthsketch.h"
 #include "src/periph/neo_pixel.h"
 #include "src/dict/cblink.h"

--- a/ainsuForthsketch.cpp
+++ b/ainsuForthsketch.cpp
@@ -285,9 +285,10 @@ void setup(void) {
   pOldHere = pHere;
   
   // Serial.print("\n warm boot message - early bird.  //  Gemma M0 29 Jul 2017\r\n          type 'warm' to reboot"); // instant confirmation
-     Serial.print("\n warm boot message - early bird.  \r\n MALAMUTE  DEV - gen-exp  31 Jan 2018\r\n          type 'warm' to reboot"); // instant confirmation
-     Serial.print("\n Wed Jan 31 00:27:18 UTC 2018");
-     Serial.print("\n 4737-a0e-01a-");
+     Serial.print("\r\n warm boot message - early bird.  \r\n KAN-MALAMUTE  DEV - gen-exp  30 Oct 2019\r\n          type 'warm' to reboot"); // instant confirmation
+     Serial.print("\r\n Wed Oct 30 18:57:28 UTC 2019");
+     Serial.print("   Trinket M0 default +DotStar");
+     Serial.print("\r\n 4737-a3d-00a-");
 
   // Serial.print("\n warm boot message - early bird.  //  Adafruit Metro M0 Express\r\n      snapshot 30 Jul 2017\r\n          type 'warm' to reboot"); // instant confirmation
   // Serial.print("\n warm boot message - early bird.  //  Adafruit Feather M0 Express\r\n      snapshot 30 Jul 2017\r\n          type 'warm' to reboot"); // instant confirmation

--- a/compatibility.h
+++ b/compatibility.h
@@ -1,11 +1,14 @@
+// Wed Oct 30 18:57:28 UTC 2019
+// 4737-a3d-00a- // ainsuForth-gen-exp
+
+// On branch testing-aa- / pre-release of 0.1.0
+
+// adafruit_trinket_m0.build.extra_flags=-DCRYSTALLESS -DADAFRUIT_TRINKET_M0 -D__SAMD21E18A__ -DARM_MATH_CM0PLUS {build.usb_flags}
+
+// previous timestamps:
 // Tue Jan 16 02:30:09 UTC 2018
 // 4737-a0d-05j-
 
-// Tue Jan 16 01:14:29 UTC 2018
-// 4737-a0d-05f-
-
-
-// previous timestamps:
 // Mon Jan 15 19:19:47 UTC 2018
 // 4737-a0d-05d-
 
@@ -48,6 +51,10 @@
 // reverse these two lines to enable SPI flashROM support:
 #define HAS_SPI_FLASH_DEMO
 #undef HAS_SPI_FLASH_DEMO
+
+#ifdef ADAFRUIT_TRINKET_M0
+  #define HAS_DOTSTAR_LIB
+#endif // #ifdef ADAFRUIT_TRINKET_M0
 
 #ifdef ADAFRUIT_FEATHER_M0_EXPRESS
   #define HAS_SPI_FLASH_DEMO

--- a/src/dict/help.cpp
+++ b/src/dict/help.cpp
@@ -18,7 +18,8 @@ const char who_str[] = "who";
 void _who(void) {
   // hex 1d10 dup 48 dump
   // _hex();
-  dStack_push(0x1d10); // nothing sacred, experiment!  YMMV.
+  // 0x1d30 Trinket M0   0x1d10 - probably for Gemma M0
+  dStack_push(0x1d30); // nothing sacred, experiment!  YMMV.
   _dupe();
   dStack_push(0x50);
   _dump();

--- a/src/kernel/signon.cpp
+++ b/src/kernel/signon.cpp
@@ -1,13 +1,17 @@
+// Wed Oct 30 18:57:28 UTC 2019
+// 4737-a3d-00a- // ainsuForth-gen-exp
+
+// On branch testing-aa- / pre-release of 0.1.0
+
+// previous timestamps:
 // Mon Jan 15 19:19:47 UTC 2018
 // 4737-a0d-05d-
 
-// previous timestamp:
 // Wed Aug  2 01:22:51 UTC 2017
 // 4735-b0c-03-
 
 #include <Arduino.h>
 #include "../../yaffa.h"
-// #include "../../Error_Codes.h"
 
 #ifdef EXT_KERN_SIGN_ON
 #include "signon.h"
@@ -15,12 +19,6 @@
 /** signOn - say Hello to the user interface via USB serial port             **/
 /******************************************************************************/
 void signOn(void) {
-  // Serial.begin(19200);     // Open serial communications:
-
-  // Serial.print("\n warm boot message - early bird."); // instant confirmation
-
-  // delay(9 * 100);
-
   // colours - entirely optional
   Serial.print("\033\133"); // ESC [
   Serial.print("\063\063"); // 33 - yellow fg
@@ -57,7 +55,7 @@ void signOn(void) {
     Serial.print("\064\064"); // 44 - blue bg
     Serial.print("m");        // for the stanza
 
-    Serial.print("  ainsuForth - 2018 - wa1tnr  ");
+    Serial.print("  ainsuForth - 2019 October - wa1tnr  ");
 
     Serial.print("\033\133"); // ESC [
     Serial.print("\064\060"); // 40 - black bg

--- a/src/periph/dotstar.cpp
+++ b/src/periph/dotstar.cpp
@@ -1,7 +1,10 @@
+// Wed Oct 30 18:57:28 UTC 2019
+// 4737-a3d-00a- // ainsuForth-gen-exp
+
+// On branch testing-aa- / pre-release of 0.1.0
+
 // Mon Jan 15 18:14:33 UTC 2018
 // 4737-a0d-05c-
-
-// version bump
 
 // Sat Jul 29 18:14:02 UTC 2017
 // 4735-b0b-01-
@@ -10,8 +13,9 @@
 
 #define NUMPIXELS 1 // Number of LEDs in strip
 
-#define DATAPIN    3
-#define CLOCKPIN   4
+// pinouts for Trinket M0 dotstar are now the defaults, 30 October 2019:
+#define DATAPIN    7 // #define DATAPIN    3  // D3 is probably for Gemma M0, unchecked
+#define CLOCKPIN   8 // #define CLOCKPIN   4  // D4 is probably for Gemma M0, unchecked
 
 Adafruit_DotStar strip = Adafruit_DotStar(
   NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BRG);

--- a/yaffa.h
+++ b/yaffa.h
@@ -33,8 +33,8 @@
 
 // -------  use this to switch between them   ---------
 
-#undef NEO_PIXEL_LIB_ENABLED  // swap these two
 #define NEO_PIXEL_LIB_ENABLED // swap these two
+#undef NEO_PIXEL_LIB_ENABLED  // swap these two
 
 // -------  use this to switch between them   ---------
 

--- a/yaffa.h
+++ b/yaffa.h
@@ -1,8 +1,12 @@
+// Wed Oct 30 18:57:28 UTC 2019
+// 4737-a3d-00a- // ainsuForth-gen-exp
+
+// On branch testing-aa- / pre-release of 0.1.0
+
 // Mon Jan 15 18:14:33 UTC 2018
 // 4737-a0d-05c-
 
 // version bump
-
 
 // Sat Nov 25 19:03:16 UTC 2017
 // 4735-b0c-09d-   the -09x- is new Nov 24, 2017.
@@ -14,9 +18,9 @@
 
 // 29 July -- not proofread very well.  Needs testing.  See diff.
 
-#include "compatibility.h" # ainsuForth selection of target board
+#include "compatibility.h" // ainsuForth selection of target board
 
-#define AINSU_ON_ADAFRUIT_GEMMA
+// #define AINSU_ON_ADAFRUIT_GEMMA // clarify this was not in use 30 Oct 2019
 
 /**  YAFFA - Yet Another Forth for Arduino                                   **/
 // scroll to end of file for intellectual property notices - wa1tnr


### PR DESCRIPTION
Update - Trinket M0 new default target.
No mechanism to detect and configure for Gemma M0,
but this is not difficult.  Follow recent mods (today) for
Trinket M0, as a model, for autoconfig to Gemma M0 specs.